### PR TITLE
Fix Microsoft.AspNetCore.SpaProxy Issues

### DIFF
--- a/GIAP.Server/GIAP.Server.csproj
+++ b/GIAP.Server/GIAP.Server.csproj
@@ -24,4 +24,8 @@
     </ProjectReference>
   </ItemGroup>
 
+  <ItemGroup>
+    <Folder Include="wwwroot\" />
+  </ItemGroup>
+
 </Project>

--- a/GIAP.Server/GIAP.Server.csproj
+++ b/GIAP.Server/GIAP.Server.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <SpaRoot>..\giap.client</SpaRoot>
     <SpaProxyLaunchCommand>npm run dev</SpaProxyLaunchCommand>
-    <SpaProxyServerUrl>https://localhost:62858</SpaProxyServerUrl>
+    <SpaProxyServerUrl>http://localhost:62858</SpaProxyServerUrl>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
   </PropertyGroup>
 

--- a/GIAP.Server/global.json
+++ b/GIAP.Server/global.json
@@ -1,0 +1,6 @@
+﻿{
+  "sdk": {
+    "version": "8.0.409",
+    "rollForward": "latestFeature"
+  }
+}

--- a/GIAP.Server/wwwroot/README.md
+++ b/GIAP.Server/wwwroot/README.md
@@ -1,0 +1,3 @@
+﻿`wwwroot` directory required for `Microsoft.AspNetCore.SpaProxy` when using `dotnet watch`.  
+`README.md` is used for this explanation, but is also used to be able to commit this directory (see this
+solution: https://stackoverflow.com/a/5305908). Otherwise, it wouldn't be possible to commit an empty directory.


### PR DESCRIPTION
Fixes some issues with Microsoft.AspNetCore.SpaProxy
* Added a `global.json` to enforce `.NET 8.*.* ` (without this a user with .NET 9 will encounter a bug, see commit description)
* Added required `wwwroot` with documentation
* Fixed SpaProxyServerUrl configuration