### PR TITLE
refactor: change 502 gateway error code messages to 500 error code

### DIFF
--- a/GIAP.Server/Controllers/IdentityProviderController.cs
+++ b/GIAP.Server/Controllers/IdentityProviderController.cs
@@ -108,7 +108,7 @@ public class IdentityProviderController(
         }
         catch (HttpRequestException)
         {
-            return StatusCode(502, "Bad Gateway: Unable to get attributes from external services.");
+            return StatusCode(500, "Unable to get attributes from external services.");
         }
         catch (Exception e)
         {
@@ -164,8 +164,8 @@ public class IdentityProviderController(
         }
         catch (HttpRequestException)
         {
-            return StatusCode(502,
-                "Bad Gateway: Unable to get data for issuance or failed to issue the credential to the IRMA server.");
+            return StatusCode(500,
+                "Unable to get data for issuance or failed to issue the credential to the IRMA server.");
         }
         catch (Exception e)
         {


### PR DESCRIPTION
The app doesn't act as a gateway so a 500 error code makes more sense. See feedback: https://github.com/privacybydesign/yivi-generic-identity-attestation-provider/pull/6#discussion_r2161317508