### PR TITLE
feat: only allow lowercase slug configuration

### DIFF
--- a/GIAP.Server/Services/IIdentityProviderService.cs
+++ b/GIAP.Server/Services/IIdentityProviderService.cs
@@ -17,8 +17,6 @@ public interface IIdentityProviderService
 
     /// <summary>
     /// Get an identity provider by its web url slug.
-    /// This method is used to find an IdentityProvider from a user input slug.
-    /// The user input slug is always converted to lowercase.
     /// </summary>
     /// <param name="slug">A web url slug, for example, "idp-slug".</param>
     /// <returns>The identity provider, if none found, it returns null.</returns>

--- a/GIAP.Server/Services/IIdentityProviderService.cs
+++ b/GIAP.Server/Services/IIdentityProviderService.cs
@@ -17,9 +17,16 @@ public interface IIdentityProviderService
 
     /// <summary>
     /// Get an identity provider by its web url slug.
+    /// This method is used to find an IdentityProvider from a user input slug.
+    /// The user input slug is always converted to lowercase.
     /// </summary>
     /// <param name="slug">A web url slug, for example, "idp-slug".</param>
     /// <returns>The identity provider, if none found, it returns null.</returns>
+    /// <remarks>
+    /// It's necessary to convert user input slugs to lowercase.
+    /// For example, it allows a user to be able to navigate to a URL like "/Slug"
+    /// and still get the expected identity provider result.
+    /// </remarks>
     IdentityProvider? GetBySlug(string slug);
 
     /// <summary>

--- a/GIAP.Server/Services/IdentityProviderService.cs
+++ b/GIAP.Server/Services/IdentityProviderService.cs
@@ -39,10 +39,10 @@ public class IdentityProviderService(IFileSystem fileSystem) : IIdentityProvider
             foreach (var identityProvider in _identityProviders)
             {
                 // If a slug is already added to the dictionary, it means a duplicate exists in the idp config file
-                if (slugs.ContainsKey(identityProvider.Slug))
+                if (slugs.ContainsKey(identityProvider.Slug.ToLower()))
                 {
                     throw new InvalidDataException(
-                        $"Duplicate slug found in identity-providers.json: {identityProvider.Slug}");
+                        $"Duplicate slug found in identity-providers.json: {identityProvider.Slug}. Slugs are counted as duplicate regardless of case sensitivity, a configured identity-providers.json with the slugs 'example' and 'Example' will cause an exception to be thrown.");
                 }
 
                 slugs[identityProvider.Slug] = true;

--- a/GIAP.Server/Services/IdentityProviderService.cs
+++ b/GIAP.Server/Services/IdentityProviderService.cs
@@ -38,11 +38,18 @@ public class IdentityProviderService(IFileSystem fileSystem) : IIdentityProvider
             var slugs = new Dictionary<string, bool>();
             foreach (var identityProvider in _identityProviders)
             {
-                // If a slug is already added to the dictionary, it means a duplicate exists in the idp config file
-                if (slugs.ContainsKey(identityProvider.Slug.ToLower()))
+                // If a slug is not lowercase, throw an exception
+                if (identityProvider.Slug != identityProvider.Slug.ToLower())
                 {
                     throw new InvalidDataException(
-                        $"Duplicate slug found in identity-providers.json: {identityProvider.Slug}. Slugs are counted as duplicate regardless of case sensitivity, a configured identity-providers.json with the slugs 'example' and 'Example' will cause an exception to be thrown.");
+                        $"Found: {identityProvider.Slug}. Slugs must be lowercase, a configured identity-providers.json with the slug 'Example' or 'EXAMPLE' will cause an exception to be thrown.");
+                }
+
+                // If a slug is already added to the dictionary, it means a duplicate exists in the idp config file
+                if (slugs.ContainsKey(identityProvider.Slug))
+                {
+                    throw new InvalidDataException(
+                        $"Duplicate slug found in identity-providers.json: {identityProvider.Slug}.");
                 }
 
                 slugs[identityProvider.Slug] = true;
@@ -55,7 +62,8 @@ public class IdentityProviderService(IFileSystem fileSystem) : IIdentityProvider
     }
 
     /// <inheritdoc/>
-    public IdentityProvider? GetBySlug(string slug) => _identityProviders.FirstOrDefault(idp => idp.Slug == slug);
+    public IdentityProvider? GetBySlug(string slug) =>
+        _identityProviders.FirstOrDefault(idp => idp.Slug == slug.ToLower());
 
     /// <inheritdoc/>
     public IReadOnlyList<IdentityProvider> GetAll() => _identityProviders;

--- a/GIAP.Tests/IdentityProviderServiceTests.cs
+++ b/GIAP.Tests/IdentityProviderServiceTests.cs
@@ -245,6 +245,71 @@ public class IdentityProviderServiceTests
         var service = new IdentityProviderService(fileSystem);
 
         Should.Throw<InvalidDataException>(() => service.Initialize()).Message
-            .ShouldBe("Duplicate slug found in identity-providers.json: example-1");
+            .ShouldBe(
+                "Duplicate slug found in identity-providers.json: example-1. Slugs are counted as duplicate regardless of case sensitivity, a configured identity-providers.json with the slugs 'example' and 'Example' will cause an exception to be thrown.");
+    }
+
+    /// <summary>
+    /// Given an invalid identity providers file with a duplicate slug
+    /// When the service is initialized,
+    /// Then an exception is thrown with the duplicate slug name
+    /// </summary>
+    /// <remarks>
+    /// This one is different from `Initialize_WithDuplicateSlug_ThrowsException` because it checks for case insensitivity.
+    /// It should also throw an exception when the slugs are the same but differ in case, for example, "example-1" and "EXAMPLE-1".
+    /// </remarks>
+    [Fact]
+    public void Initialize_WithDuplicateSlug_ThrowsException_CaseInsensitiveVersion()
+    {
+        var fileSystem = Substitute.For<IFileSystem>();
+        var expectedPath = Path.Combine(
+            AppContext.BaseDirectory,
+            "Configuration",
+            "identity-providers.json"
+        );
+
+        fileSystem.Exists(expectedPath).Returns(true);
+
+        // JSON with a duplicate slug
+        const string json = """
+                            [
+                              {
+                                "name": "Example Identity Provider 1",
+                                "slug": "example-1",
+                                "openIdWellKnownUrl": "https://example.local/.well-known/openid-configuration",
+                                "clientId": "123-456-789",
+                                "clientSecret": "ABC-123-XYZ",
+                                "callbackPath": "/api/callback-signin-example-1",
+                                "schemePath": "pbdf/Issues/example1/description.xml",
+                                "issuanceValidityInMonths": 6,
+                                "attributeMapping": {
+                                  "id": "id",
+                                  "given_name": "givenName"
+                                }
+                              },
+                              {
+                                "name": "Example Identity Provider 1",
+                                "slug": "EXAMPLE-1",
+                                "openIdWellKnownUrl": "https://example.local/.well-known/openid-configuration",
+                                "clientId": "123-456-789",
+                                "clientSecret": "ABC-123-XYZ",
+                                "callbackPath": "/api/callback-signin-example-1",
+                                "schemePath": "pbdf/Issues/example1/description.xml",
+                                "issuanceValidityInMonths": 6,
+                                "attributeMapping": {
+                                  "id": "id",
+                                  "given_name": "givenName"
+                                }
+                              }
+                            ]
+                            """;
+
+        fileSystem.ReadAllText(expectedPath).Returns(json);
+
+        var service = new IdentityProviderService(fileSystem);
+
+        Should.Throw<InvalidDataException>(() => service.Initialize()).Message
+            .ShouldBe(
+                "Duplicate slug found in identity-providers.json: EXAMPLE-1. Slugs are counted as duplicate regardless of case sensitivity, a configured identity-providers.json with the slugs 'example' and 'Example' will cause an exception to be thrown.");
     }
 }

--- a/GIAP.Tests/IdentityProviderServiceTests.cs
+++ b/GIAP.Tests/IdentityProviderServiceTests.cs
@@ -245,21 +245,16 @@ public class IdentityProviderServiceTests
         var service = new IdentityProviderService(fileSystem);
 
         Should.Throw<InvalidDataException>(() => service.Initialize()).Message
-            .ShouldBe(
-                "Duplicate slug found in identity-providers.json: example-1. Slugs are counted as duplicate regardless of case sensitivity, a configured identity-providers.json with the slugs 'example' and 'Example' will cause an exception to be thrown.");
+            .ShouldBe("Duplicate slug found in identity-providers.json: example-1.");
     }
 
     /// <summary>
-    /// Given an invalid identity providers file with a duplicate slug
+    /// Given an invalid identity providers file with a lower case slug
     /// When the service is initialized,
-    /// Then an exception is thrown with the duplicate slug name
+    /// Then an exception is thrown with the slug
     /// </summary>
-    /// <remarks>
-    /// This one is different from `Initialize_WithDuplicateSlug_ThrowsException` because it checks for case insensitivity.
-    /// It should also throw an exception when the slugs are the same but differ in case, for example, "example-1" and "EXAMPLE-1".
-    /// </remarks>
     [Fact]
-    public void Initialize_WithDuplicateSlug_ThrowsException_CaseInsensitiveVersion()
+    public void Initialize_WithSlugNotLowerCase_ThrowsException()
     {
         var fileSystem = Substitute.For<IFileSystem>();
         var expectedPath = Path.Combine(
@@ -310,6 +305,6 @@ public class IdentityProviderServiceTests
 
         Should.Throw<InvalidDataException>(() => service.Initialize()).Message
             .ShouldBe(
-                "Duplicate slug found in identity-providers.json: EXAMPLE-1. Slugs are counted as duplicate regardless of case sensitivity, a configured identity-providers.json with the slugs 'example' and 'Example' will cause an exception to be thrown.");
+                "Found: EXAMPLE-1. Slugs must be lowercase, a configured identity-providers.json with the slug 'Example' or 'EXAMPLE' will cause an exception to be thrown.");
     }
 }


### PR DESCRIPTION
If identity-providers.json is configured with the slugs "EXAMPLE-1" and "example-1", it should throw an exception.
See feedback: https://github.com/privacybydesign/yivi-generic-identity-attestation-provider/pull/6#discussion_r2161546833

Also see: https://github.com/privacybydesign/yivi-generic-identity-attestation-provider/pull/6#discussion_r2161542596

However some parts of the app depend on it being case sensitive such as in IdentityProvidersExtension.cs.

So alternatively we could enforce all slugs to be lowercase and throw an exception otherwise.

EDIT: After discussion, enforce lowercase slugs only, but convert user input slugs to lowercase. So for example when a user navigates to '/EXAMPLE' it will be converted to '/example' and the user will still get their expected result.