### PR TITLE
fix: middleware health order

### DIFF
--- a/GIAP.Server/Middleware/IdentityProviderAuthMiddleware.cs
+++ b/GIAP.Server/Middleware/IdentityProviderAuthMiddleware.cs
@@ -20,13 +20,6 @@ public class IdentityProviderAuthMiddleware(RequestDelegate next, IIdentityProvi
 {
     public async Task InvokeAsync(HttpContext context)
     {
-        // Check: Allow health check to pass through without authentication
-        if (context.Request.Path.Equals("/health"))
-        {
-            await next(context);
-            return;
-        }
-
         // Check: Allow non-backend requests to pass through without authentication
         if (!context.Request.Path.StartsWithSegments("/api"))
         {

--- a/GIAP.Server/Program.cs
+++ b/GIAP.Server/Program.cs
@@ -61,8 +61,10 @@ builder.Services.Configure<ForwardedHeadersOptions>(options =>
 var app = builder.Build();
 
 app.UseForwardedHeaders();
-app.UseAuthentication();
 
+app.UseHealthChecks("/health");
+
+app.UseAuthentication();
 app.UseMiddleware<IdentityProviderAuthMiddleware>();
 
 app.UseDefaultFiles();
@@ -76,7 +78,6 @@ if (app.Environment.IsDevelopment())
 }
 
 app.MapControllers();
-app.MapHealthChecks("/health");
 app.MapFallbackToFile("/index.html");
 
 app.Run();


### PR DESCRIPTION
Fixed the middleware order so it is no longer necessary to check on `/health` in the auth middleware.